### PR TITLE
Refactoring for easier reuse, merge CLI and config

### DIFF
--- a/src/PHPSemVerChecker/Configuration/Configuration.php
+++ b/src/PHPSemVerChecker/Configuration/Configuration.php
@@ -11,6 +11,19 @@ class Configuration
 	 * @var array
 	 */
 	protected $mapping = [];
+	/**
+	 * @var \Noodlehaus\Config
+	 */
+	protected $config;
+
+	/**
+	 * @param string|array $path
+	 */
+	public function __construct($path)
+	{
+		$this->config = new Config($path);
+		$this->extractMapping($this->get('level.mapping', []));
+	}
 
 	/**
 	 * @param string|array $file
@@ -18,12 +31,7 @@ class Configuration
 	 */
 	public static function fromFile($file)
 	{
-		$configuration = new Configuration();
-		$config = new Config($file);
-
-		$configuration->extractMapping($config->get('level.mapping', []));
-
-		return $configuration;
+		return new Configuration($file);
 	}
 
 	/**
@@ -51,5 +59,40 @@ class Configuration
 	public function getLevelMapping()
 	{
 		return $this->mapping;
+	}
+
+	/**
+	 * @see \Noodlehaus\Config::get
+	 * @param string $key
+	 * @param mixed|null $default
+	 * @return array|mixed|null
+	 */
+	public function get($key, $default = null)
+	{
+		return $this->config->get($key, $default);
+	}
+
+	/**
+	 * @see \Noodlehaus\Config::set
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set($key, $value)
+	{
+		$this->config->set($key, $value);
+	}
+
+	/**
+	 * Merge this configuration with an associative array.
+	 *
+	 * Note that dot notation is used for keys.
+	 *
+	 * @param array $data
+	 */
+	public function merge($data)
+	{
+		foreach ($data as $key => $value) {
+			$this->set($key, $value);
+		}
 	}
 }

--- a/src/PHPSemVerChecker/Console/Command/CompareCommand.php
+++ b/src/PHPSemVerChecker/Console/Command/CompareCommand.php
@@ -5,6 +5,7 @@ namespace PHPSemVerChecker\Console\Command;
 use PHPSemVerChecker\Analyzer\Analyzer;
 use PHPSemVerChecker\Configuration\Configuration;
 use PHPSemVerChecker\Configuration\LevelMapping;
+use PHPSemVerChecker\Console\InputMerger;
 use PHPSemVerChecker\Filter\SourceFilter;
 use PHPSemVerChecker\Finder\Finder;
 use PHPSemVerChecker\Reporter\JsonReporter;
@@ -40,8 +41,10 @@ class CompareCommand extends Command {
 	{
 		$startTime = microtime(true);
 
-		$config = $input->getOption('config');
-		$configuration = $config ? Configuration::fromFile($config) : Configuration::defaults();
+		$configPath = $input->getOption('config');
+		$configuration = $configPath ? Configuration::fromFile($configPath) : Configuration::defaults();
+		$im = new InputMerger();
+		$im->merge($input, $configuration);
 
 		// Set overrides
 		LevelMapping::setOverrides($configuration->getLevelMapping());

--- a/src/PHPSemVerChecker/Console/Command/CompareCommand.php
+++ b/src/PHPSemVerChecker/Console/Command/CompareCommand.php
@@ -42,10 +42,9 @@ class CompareCommand extends Command {
 			]);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output)
+	protected function initialize(InputInterface $input, OutputInterface $output)
 	{
-		$startTime = microtime(true);
-
+		parent::initialize($input, $output);
 		$configPath = $input->getOption('config');
 		$this->config = $configPath ? Configuration::fromFile($configPath) : Configuration::defaults();
 		$im = new InputMerger();
@@ -53,6 +52,12 @@ class CompareCommand extends Command {
 
 		// Set overrides
 		LevelMapping::setOverrides($this->config->getLevelMapping());
+	}
+
+
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$startTime = microtime(true);
 
 		$finder = new Finder();
 		$scannerBefore = new Scanner();

--- a/src/PHPSemVerChecker/Console/Command/CompareCommand.php
+++ b/src/PHPSemVerChecker/Console/Command/CompareCommand.php
@@ -19,6 +19,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CompareCommand extends Command {
+	/**
+	 * @var Configuration
+	 */
+	protected $config;
+
 	protected function configure()
 	{
 		$this
@@ -42,24 +47,24 @@ class CompareCommand extends Command {
 		$startTime = microtime(true);
 
 		$configPath = $input->getOption('config');
-		$configuration = $configPath ? Configuration::fromFile($configPath) : Configuration::defaults();
+		$this->config = $configPath ? Configuration::fromFile($configPath) : Configuration::defaults();
 		$im = new InputMerger();
-		$im->merge($input, $configuration);
+		$im->merge($input, $this->config);
 
 		// Set overrides
-		LevelMapping::setOverrides($configuration->getLevelMapping());
+		LevelMapping::setOverrides($this->config->getLevelMapping());
 
 		$finder = new Finder();
 		$scannerBefore = new Scanner();
 		$scannerAfter = new Scanner();
 
-		$sourceBefore = $configuration->get('source-before');
-		$includeBefore = $configuration->get('include-before');
-		$excludeBefore = $configuration->get('exclude-before');
+		$sourceBefore = $this->config->get('source-before');
+		$includeBefore = $this->config->get('include-before');
+		$excludeBefore = $this->config->get('exclude-before');
 
-		$sourceAfter = $configuration->get('source-after');
-		$includeAfter = $configuration->get('include-after');
-		$excludeAfter = $configuration->get('exclude-after');
+		$sourceAfter = $this->config->get('source-after');
+		$includeAfter = $this->config->get('include-after');
+		$excludeAfter = $this->config->get('exclude-after');
 
 		$sourceBefore = $finder->findFromString($sourceBefore, $includeBefore, $excludeBefore);
 		$sourceAfter = $finder->findFromString($sourceAfter, $includeAfter, $excludeAfter);
@@ -68,8 +73,8 @@ class CompareCommand extends Command {
 		$identicalCount = $sourceFilter->filter($sourceBefore, $sourceAfter);
 
 		$progress = new ProgressScanner($output);
-		$progress->addJob($configuration->get('source-before'), $sourceBefore, $scannerBefore);
-		$progress->addJob($configuration->get('source-after'), $sourceAfter, $scannerAfter);
+		$progress->addJob($this->config->get('source-before'), $sourceBefore, $scannerBefore);
+		$progress->addJob($this->config->get('source-after'), $sourceAfter, $scannerAfter);
 		$progress->runJobs();
 
 		$registryBefore = $scannerBefore->getRegistry();
@@ -79,10 +84,10 @@ class CompareCommand extends Command {
 		$report = $analyzer->analyze($registryBefore, $registryAfter);
 
 		$reporter = new Reporter($report);
-		$reporter->setFullPath($configuration->get('full-path'));
+		$reporter->setFullPath($this->config->get('full-path'));
 		$reporter->output($output);
 
-		$toJson = $configuration->get('to-json');
+		$toJson = $this->config->get('to-json');
 		if ($toJson) {
 			$jsonReporter = new JsonReporter($report, $toJson);
 			$jsonReporter->output();

--- a/src/PHPSemVerChecker/Console/Command/CompareCommand.php
+++ b/src/PHPSemVerChecker/Console/Command/CompareCommand.php
@@ -9,9 +9,9 @@ use PHPSemVerChecker\Filter\SourceFilter;
 use PHPSemVerChecker\Finder\Finder;
 use PHPSemVerChecker\Reporter\JsonReporter;
 use PHPSemVerChecker\Reporter\Reporter;
+use PHPSemVerChecker\Scanner\ProgressScanner;
 use PHPSemVerChecker\Scanner\Scanner;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -64,22 +64,10 @@ class CompareCommand extends Command {
 		$sourceFilter = new SourceFilter();
 		$identicalCount = $sourceFilter->filter($sourceBefore, $sourceAfter);
 
-		$progress = new ProgressBar($output, count($sourceBefore) + count($sourceAfter));
-		$progress->setFormat("%message%\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%");
-		$output->writeln('');
-		$progress->setMessage('Scanning before files');
-		foreach ($sourceBefore as $file) {
-			$scannerBefore->scan($file);
-			$progress->advance();
-		}
-
-		$progress->setMessage('Scanning after files');
-		foreach ($sourceAfter as $file) {
-			$scannerAfter->scan($file);
-			$progress->advance();
-		}
-
-		$progress->clear();
+		$progress = new ProgressScanner($output);
+		$progress->addJob($input->getArgument('source-before'), $sourceBefore, $scannerBefore);
+		$progress->addJob($input->getArgument('source-after'), $sourceAfter, $scannerAfter);
+		$progress->runJobs();
 
 		$registryBefore = $scannerBefore->getRegistry();
 		$registryAfter = $scannerAfter->getRegistry();

--- a/src/PHPSemVerChecker/Console/Command/CompareCommand.php
+++ b/src/PHPSemVerChecker/Console/Command/CompareCommand.php
@@ -53,13 +53,13 @@ class CompareCommand extends Command {
 		$scannerBefore = new Scanner();
 		$scannerAfter = new Scanner();
 
-		$sourceBefore = $input->getArgument('source-before');
-		$includeBefore = $input->getOption('include-before');
-		$excludeBefore = $input->getOption('exclude-before');
+		$sourceBefore = $configuration->get('source-before');
+		$includeBefore = $configuration->get('include-before');
+		$excludeBefore = $configuration->get('exclude-before');
 
-		$sourceAfter = $input->getArgument('source-after');
-		$includeAfter = $input->getOption('include-after');
-		$excludeAfter = $input->getOption('exclude-after');
+		$sourceAfter = $configuration->get('source-after');
+		$includeAfter = $configuration->get('include-after');
+		$excludeAfter = $configuration->get('exclude-after');
 
 		$sourceBefore = $finder->findFromString($sourceBefore, $includeBefore, $excludeBefore);
 		$sourceAfter = $finder->findFromString($sourceAfter, $includeAfter, $excludeAfter);
@@ -68,8 +68,8 @@ class CompareCommand extends Command {
 		$identicalCount = $sourceFilter->filter($sourceBefore, $sourceAfter);
 
 		$progress = new ProgressScanner($output);
-		$progress->addJob($input->getArgument('source-before'), $sourceBefore, $scannerBefore);
-		$progress->addJob($input->getArgument('source-after'), $sourceAfter, $scannerAfter);
+		$progress->addJob($configuration->get('source-before'), $sourceBefore, $scannerBefore);
+		$progress->addJob($configuration->get('source-after'), $sourceAfter, $scannerAfter);
 		$progress->runJobs();
 
 		$registryBefore = $scannerBefore->getRegistry();
@@ -79,10 +79,10 @@ class CompareCommand extends Command {
 		$report = $analyzer->analyze($registryBefore, $registryAfter);
 
 		$reporter = new Reporter($report);
-		$reporter->setFullPath($input->getOption('full-path'));
+		$reporter->setFullPath($configuration->get('full-path'));
 		$reporter->output($output);
 
-		$toJson = $input->getOption('to-json');
+		$toJson = $configuration->get('to-json');
 		if ($toJson) {
 			$jsonReporter = new JsonReporter($report, $toJson);
 			$jsonReporter->output();

--- a/src/PHPSemVerChecker/Console/InputMerger.php
+++ b/src/PHPSemVerChecker/Console/InputMerger.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PHPSemVerChecker\Console;
+
+use PHPSemVerChecker\Configuration\Configuration;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Merges CLI input with existing configuration values.
+ *
+ * This is to ensure that CLI input has priority and is prepared for validation
+ * by symfony/console commands.
+ */
+class InputMerger
+{
+	/**
+	 * @param \Symfony\Component\Console\Input\InputInterface $input
+	 * @param \PHPSemVerChecker\Configuration\Configuration $config
+	 */
+	public function merge(InputInterface $input, Configuration $config)
+	{
+		$missingArguments = $this->getKeysOfNullValues($input->getArguments());
+		foreach ($missingArguments as $key) {
+			$input->setArgument($key, $config->get($key));
+		}
+		$missingOptions = $this->getKeysOfNullValues($input->getOptions());
+		foreach ($missingOptions as $key) {
+			$input->setOption($key, $config->get($key));
+		}
+		$config->merge(array_merge($input->getArguments(), $input->getOptions()));
+	}
+
+	/**
+	 * @param array $array
+	 * @return array
+	 */
+	private function getKeysOfNullValues(array $array)
+	{
+		return array_keys(array_filter($array, 'is_null'));
+	}
+}

--- a/src/PHPSemVerChecker/Scanner/ProgressScanner.php
+++ b/src/PHPSemVerChecker/Scanner/ProgressScanner.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace PHPSemVerChecker\Scanner;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ProgressScanner helps run and display the progress of a scan job.
+ */
+class ProgressScanner
+{
+	/**
+	 * @var string[][]
+	 */
+	private $fileLists = [];
+	/**
+	 * @var \PHPSemVerChecker\Scanner\Scanner[]
+	 */
+	private $scanners = [];
+	/**
+	 * @var \Symfony\Component\Console\Output\OutputInterface
+	 */
+	private $output;
+	/**
+	 * @var \Symfony\Component\Console\Helper\ProgressBar
+	 */
+	private $progressBar;
+
+	/**
+	 * @param \Symfony\Component\Console\Output\OutputInterface $output
+	 */
+	public function __construct(OutputInterface $output)
+	{
+		$this->output = $output;
+	}
+
+	/**
+	 * @param string $name
+	 * @param string[] $fileList
+	 * @param \PHPSemVerChecker\Scanner\Scanner $scanner
+	 */
+	public function addJob($name, $fileList, $scanner)
+	{
+		$this->fileLists[$name] = $fileList;
+		$this->scanners[$name] = $scanner;
+	}
+
+	/**
+	 * Run all registered jobs.
+	 */
+	public function runJobs()
+	{
+		foreach (array_keys($this->scanners) as $jobName) {
+			$this->runJob($jobName);
+		}
+	}
+
+	/**
+	 * Run a single job.
+	 *
+	 * @param string $jobName
+	 */
+	public function runJob($jobName)
+	{
+		$progress = $this->getProgressBar();
+		$progress->setMessage('Scanning ' . $jobName);
+		$scanner = $this->scanners[$jobName];
+		foreach ($this->fileLists[$jobName] as $filePath) {
+			$scanner->scan($filePath);
+			$progress->advance();
+		}
+		if ($progress->getProgress() === $progress->getMaxSteps()) {
+			$progress->clear();
+		}
+	}
+
+	/**
+	 * @return int
+	 */
+	private function getFileCount()
+	{
+		return array_sum(array_map('count', $this->fileLists));
+	}
+
+	/**
+	 * @return \Symfony\Component\Console\Helper\ProgressBar
+	 */
+	private function getProgressBar()
+	{
+		if ($this->progressBar === null) {
+			$this->progressBar = new ProgressBar($this->output, $this->getFileCount());
+			$this->progressBar->setFormat("%message%\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%");
+			$this->output->writeln('');
+		}
+		return $this->progressBar;
+	}
+}

--- a/tests/PHPSemVerChecker/Configuration/ConfigurationTest.php
+++ b/tests/PHPSemVerChecker/Configuration/ConfigurationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PHPSemVerChecker\Test\Configuration;
+
+use PHPSemVerChecker\Configuration\Configuration;
+use PHPSemVerChecker\SemanticVersioning\Level;
+use PHPUnit_Framework_TestCase;
+
+class ConfigurationTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var \PHPSemVerChecker\Configuration\Configuration
+	 */
+	protected $config;
+
+	public function setUp()
+	{
+		$this->config = new Configuration([__DIR__.'/../../fixtures/configuration/php-semver-checker.json']);
+	}
+
+	public function testGet()
+	{
+		$this->assertEquals('src', $this->config->get('include-before'));
+	}
+
+	public function testGetDefault()
+	{
+		$this->assertEquals('default', $this->config->get('missing key', 'default'));
+	}
+
+	public function testSet()
+	{
+		$unique = new \stdClass();
+		$this->config->set('any key', $unique);
+		$this->assertEquals($unique, $this->config->get('any key'));
+	}
+
+	public function testGetLevelMapping(){
+		$levelMapping = $this->config->getLevelMapping();
+		$this->assertTrue(is_array($levelMapping));
+		$this->assertEquals($levelMapping['V001'], Level::PATCH);
+		$this->assertEquals($levelMapping['V006'], Level::MAJOR);
+	}
+}

--- a/tests/PHPSemVerChecker/Console/InputMergerTest.php
+++ b/tests/PHPSemVerChecker/Console/InputMergerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PHPSemVerChecker\Test\Console;
+
+use PHPSemVerChecker\Configuration\Configuration;
+use PHPSemVerChecker\Console\Command\CompareCommand;
+use PHPSemVerChecker\Console\InputMerger;
+use Symfony\Component\Console\Input\StringInput;
+
+class InputMergerTest extends \PHPUnit_Framework_TestCase
+{
+	public function testMerge()
+	{
+		$config = new Configuration([]);
+		// Prepare options and arguments
+		$config->set('include-before', 'in-before config');
+		$config->set('source-after', 'src-after config');
+
+		// Specify options and arguments for input
+		$input = new StringInput('--include-before "in-before cli" "src-before cli"');
+		$command = new CompareCommand();
+		$input->bind($command->getDefinition());
+		$this->assertEquals('in-before cli', $input->getOption('include-before'), 'Test setup: Could not prepare input arguments');
+
+		$im = new InputMerger();
+		$im->merge($input, $config);
+		$this->assertEquals('in-before cli', $config->get('include-before'), 'Configuration must be overwritten by CLI option');
+		$this->assertEquals('src-before cli', $config->get('source-before'), 'Configuration must be overwritten by CLI argument');
+		$this->assertEquals('src-before cli', $input->getArgument('source-before'), 'Input arguments must not be overwritten by empty configuration');
+		$this->assertEquals('src-after config', $config->get('source-after'), 'Configuration must not be overwritten by empty CLI argument');
+		$this->assertEquals('src-after config', $input->getArgument('source-after'), 'Missing input arguments must take on existing configuration');
+	}
+}

--- a/tests/fixtures/configuration/php-semver-checker.json
+++ b/tests/fixtures/configuration/php-semver-checker.json
@@ -1,0 +1,10 @@
+{
+  "include-before": "src",
+  "include-after": "src",
+  "level": {
+    "mapping": {
+      "V001": "PATCH",
+      "V006": "MAJOR"
+    }
+  }
+}


### PR DESCRIPTION
See #72 

Mostly trying to shrink down all the boiler-plate in CompareCommand's `execute` method.

What do you think so far? @tomzx 

See commit "Merge configuration and CLI input" for implementing #67.
