### PR TITLE
Tweaked travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ php:
 
 sudo: false
 
-before_script:
-    - composer self-update
-    - composer update
+install:
+    - composer install --no-interaction --prefer-source
 
 script:
     - php vendor/bin/phpunit


### PR DESCRIPTION
Installing dependencies should be done within `install` on travis. Also, I've replaced `composer update` with a better command that does not hang potentially waiting for user input and does not selfishly use github api requests downloading deps, busting the rate limit for others on travis that might have a more genuine use case for it.
