### PR TITLE
Dont treat case changes in method names as breaking

### DIFF
--- a/src/PHPSemVerChecker/Analyzer/ClassMethodAnalyzer.php
+++ b/src/PHPSemVerChecker/Analyzer/ClassMethodAnalyzer.php
@@ -19,107 +19,179 @@ use PHPSemVerChecker\Operation\ClassMethodParameterTypingRemoved;
 use PHPSemVerChecker\Operation\ClassMethodRemoved;
 use PHPSemVerChecker\Report\Report;
 
-class ClassMethodAnalyzer {
-	protected $context;
-	protected $fileBefore;
-	protected $fileAfter;
+class ClassMethodAnalyzer
+{
+    protected $context;
+    protected $fileBefore;
+    protected $fileAfter;
 
-	/**
-	 * @param string $context
-	 * @param string $fileBefore
-	 * @param string $fileAfter
-	 */
-	public function __construct($context, $fileBefore = null, $fileAfter = null)
-	{
-		$this->context = $context;
-		$this->fileBefore = $fileBefore;
-		$this->fileAfter = $fileAfter;
-	}
+    /**
+     * @param string $context
+     * @param string $fileBefore
+     * @param string $fileAfter
+     */
+    public function __construct($context, $fileBefore = null, $fileAfter = null)
+    {
+        $this->context = $context;
+        $this->fileBefore = $fileBefore;
+        $this->fileAfter = $fileAfter;
+    }
 
-	public function analyze(Stmt $contextBefore, Stmt $contextAfter)
-	{
-		$report = new Report();
+    public function analyze(Stmt $contextBefore, Stmt $contextAfter)
+    {
+        $report = new Report();
 
-		$methodsBefore = $contextBefore->getMethods();
-		$methodsAfter = $contextAfter->getMethods();
+        $methodsBefore = $contextBefore->getMethods();
+        $methodsAfter = $contextAfter->getMethods();
 
-		$methodsBeforeKeyed = [];
-		foreach ($methodsBefore as $method) {
-			$methodsBeforeKeyed[$method->name] = $method;
-		}
+        $methodsBeforeKeyed = [];
+        foreach ($methodsBefore as $method) {
+            $methodsBeforeKeyed[strtolower($method->name)] = $method;
+        }
 
-		$methodsAfterKeyed = [];
-		foreach ($methodsAfter as $method) {
-			$methodsAfterKeyed[$method->name] = $method;
-		}
+        $methodsAfterKeyed = [];
+        foreach ($methodsAfter as $method) {
+            $methodsAfterKeyed[strtolower($method->name)] = $method;
+        }
 
-		$methodNamesBefore = array_keys($methodsBeforeKeyed);
-		$methodNamesAfter = array_keys($methodsAfterKeyed);
-		$methodsAdded = array_diff($methodNamesAfter, $methodNamesBefore);
-		$methodsRemoved = array_diff($methodNamesBefore, $methodNamesAfter);
-		$methodsToVerify = array_intersect($methodNamesBefore, $methodNamesAfter);
+        // Here we only care about public methods as they are the only part of the API we care about
 
-		// Here we only care about public methods as they are the only part of the API we care about
+        $methodNamesNotAddedOrRemoved = [];
 
-		// Removed methods can either be implemented in parent classes or not exist anymore
-		foreach ($methodsRemoved as $method) {
-			$methodBefore = $methodsBeforeKeyed[$method];
-			$data = new ClassMethodRemoved($this->context, $this->fileBefore, $contextBefore, $methodBefore);
-			$report->add($this->context, $data);
-		}
+        foreach($methodsBefore as $methodBefore)
+        {
+            // Removed methods can either be implemented in parent classes or not exist anymore
+            if($this->wasMethodRemoved($methodBefore, $methodsAfter))
+            {
+                $data = new ClassMethodRemoved($this->context, $this->fileBefore, $contextBefore, $methodBefore);
+                $report->add($this->context, $data);
+            } else {
+                $methodNamesNotAddedOrRemoved[strtolower($methodBefore->name)] = true;
+            }
+        }
 
-		foreach ($methodsToVerify as $method) {
-			/** @var \PhpParser\Node\Stmt\ClassMethod $methodBefore */
-			$methodBefore = $methodsBeforeKeyed[$method];
-			/** @var \PhpParser\Node\Stmt\ClassMethod $methodAfter */
-			$methodAfter = $methodsAfterKeyed[$method];
+        foreach($methodsAfter as $methodAfter)
+        {
+            // Added methods implies MINOR BUMP
+            if($this->wasMethodAdded($methodAfter, $methodsBefore))
+            {
+                $data = new ClassMethodAdded($this->context, $this->fileAfter, $contextAfter, $methodAfter);
+                $report->add($this->context, $data);
+            } else {
+                $methodNamesNotAddedOrRemoved[strtolower($methodAfter->name)] = true;
+            }
+        }
 
-			// Leave non-strict comparison here
-			if ($methodBefore != $methodAfter) {
-				$paramsBefore = $methodBefore->params;
-				$paramsAfter = $methodAfter->params;
+        foreach (array_keys($methodNamesNotAddedOrRemoved) as $methodName) {
 
-				$signatureResult = Signature::analyze($paramsBefore, $paramsAfter);
+            /** @var \PhpParser\Node\Stmt\ClassMethod $methodBefore */
+            $methodBefore = $methodsBeforeKeyed[$methodName];
+            /** @var \PhpParser\Node\Stmt\ClassMethod $methodAfter */
+            $methodAfter = $methodsAfterKeyed[$methodName];
 
-				$changes = [
-					'parameter_added' => ClassMethodParameterAdded::class,
-					'parameter_removed' => ClassMethodParameterRemoved::class,
-					'parameter_renamed' => ClassMethodParameterNameChanged::class,
-					'parameter_typing_added' => ClassMethodParameterTypingAdded::class,
-					'parameter_typing_removed' => ClassMethodParameterTypingRemoved::class,
-					'parameter_default_added' => ClassMethodParameterDefaultAdded::class,
-					'parameter_default_removed' => ClassMethodParameterDefaultRemoved::class,
-					'parameter_default_value_changed' => ClassMethodParameterDefaultValueChanged::class,
-				];
+            if (!$this->areMethodsEqual($methodBefore, $methodAfter)) {
 
-				foreach ($changes as $changeType => $class) {
-					if ( ! $signatureResult[$changeType]) {
-						continue;
-					}
-					if (is_a($class, ClassMethodOperationUnary::class, true)) {
-						$data = new $class($this->context, $this->fileAfter, $contextAfter, $methodAfter);
-					} else {
-						$data = new $class($this->context, $this->fileBefore, $contextBefore, $methodBefore, $this->fileAfter, $contextAfter, $methodAfter);
-					}
-					$report->add($this->context, $data);
-				}
+                $paramsBefore = $methodBefore->params;
+                $paramsAfter = $methodAfter->params;
 
-				// Difference in source code
-				// Cast to array because interfaces do not have stmts (= null)
-				if ( ! Implementation::isSame((array)$methodBefore->stmts, (array)$methodAfter->stmts)) {
-					$data = new ClassMethodImplementationChanged($this->context, $this->fileBefore, $contextBefore, $methodBefore, $this->fileAfter, $contextAfter, $methodAfter);
-					$report->add($this->context, $data);
-				}
-			}
-		}
+                $signatureResult = Signature::analyze($paramsBefore, $paramsAfter);
 
-		// Added methods implies MINOR BUMP
-		foreach ($methodsAdded as $method) {
-			$methodAfter = $methodsAfterKeyed[$method];
-			$data = new ClassMethodAdded($this->context, $this->fileAfter, $contextAfter, $methodAfter);
-			$report->add($this->context, $data);
-		}
+                $changes = [
+                    'parameter_added' => ClassMethodParameterAdded::class,
+                    'parameter_removed' => ClassMethodParameterRemoved::class,
+                    'parameter_renamed' => ClassMethodParameterNameChanged::class,
+                    'parameter_typing_added' => ClassMethodParameterTypingAdded::class,
+                    'parameter_typing_removed' => ClassMethodParameterTypingRemoved::class,
+                    'parameter_default_added' => ClassMethodParameterDefaultAdded::class,
+                    'parameter_default_removed' => ClassMethodParameterDefaultRemoved::class,
+                    'parameter_default_value_changed' => ClassMethodParameterDefaultValueChanged::class,
+                ];
 
-		return $report;
-	}
+                foreach ($changes as $changeType => $class) {
+                    if (!$signatureResult[$changeType]) {
+                        continue;
+                    }
+                    if (is_a($class, ClassMethodOperationUnary::class, true)) {
+                        $data = new $class($this->context, $this->fileAfter, $contextAfter, $methodAfter);
+                    } else {
+                        $data = new $class(
+                            $this->context,
+                            $this->fileBefore,
+                            $contextBefore,
+                            $methodBefore,
+                            $this->fileAfter,
+                            $contextAfter,
+                            $methodAfter
+                        );
+                    }
+                    $report->add($this->context, $data);
+                }
+
+                // Difference in source code
+                // Cast to array because interfaces do not have stmts (= null)
+                if (!Implementation::isSame((array)$methodBefore->stmts, (array)$methodAfter->stmts)) {
+                    $data = new ClassMethodImplementationChanged(
+                        $this->context,
+                        $this->fileBefore,
+                        $contextBefore,
+                        $methodBefore,
+                        $this->fileAfter,
+                        $contextAfter,
+                        $methodAfter
+                    );
+                    $report->add($this->context, $data);
+                }
+            }
+        }
+
+        return $report;
+    }
+
+    private function areMethodsEqual(Stmt\ClassMethod $methodBefore, Stmt\ClassMethod $methodAfter)
+    {
+        if ($methodBefore == $methodAfter) {
+            return true;
+        };
+
+        return strtolower($methodBefore->name) === strtolower($methodAfter->name)
+            && $methodBefore->isPrivate() === $methodAfter->isPrivate()
+            && $methodBefore->isAbstract() === $methodAfter->isAbstract()
+            && $methodBefore->isFinal() === $methodAfter->isFinal()
+            && $methodBefore->isProtected() === $methodAfter->isProtected()
+            && $methodBefore->isPublic() === $methodAfter->isPublic()
+            && $methodBefore->isStatic() === $methodAfter->isStatic()
+            && $methodBefore->getReturnType() === $methodAfter->getReturnType()
+                // statements are objects, cannot be compared with ===
+            && $methodBefore->getStmts() == $methodAfter->getStmts()
+            && $methodBefore->getParams() === $methodAfter->getParams()
+            && $methodBefore->returnsByRef() === $methodAfter->returnsByRef()
+            && $methodBefore->getType() === $methodAfter->getType()
+            && $methodBefore->getAttributes() === $methodAfter->getAttributes();
+    }
+
+    private function wasMethodAdded(Stmt\ClassMethod $method, $methodsAfter)
+    {
+        foreach($methodsAfter as $methodAfter)
+        {
+            if(strtolower($method->name) == strtolower($methodAfter->name))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function wasMethodRemoved(Stmt\ClassMethod $method, $methodsBefore)
+    {
+        foreach($methodsBefore as $methodBefore)
+        {
+            if(strtolower($method->name) == strtolower($methodBefore->name))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/tests/PHPSemVerChecker/Analyzer/ClassMethodAnalyzerTest.php
+++ b/tests/PHPSemVerChecker/Analyzer/ClassMethodAnalyzerTest.php
@@ -697,15 +697,46 @@ class ClassMethodAnalyzerTest extends TestCase
 		$this->assertSame('tmp::tmpMethod', $report[$context][$expectedLevel][0]->getTarget());
 	}
 
-	public function providerImplementationChanged()
-	{
-		return [
-			['class', 'public', 'V023'],
-			['class', 'protected', 'V024'],
-			['class', 'private', 'V025'],
-			['trait', 'public', 'V052'],
-			['trait', 'protected', 'V053'],
-			['trait', 'private', 'V054'],
-		];
-	}
+    public function providerImplementationChanged()
+    {
+        return [
+            ['class', 'public', 'V023'],
+            ['class', 'protected', 'V024'],
+            ['class', 'private', 'V025'],
+            ['trait', 'public', 'V052'],
+            ['trait', 'protected', 'V053'],
+            ['trait', 'private', 'V054'],
+        ];
+    }
+
+    public function testClassMethodCaseChangeIsIgnored()
+    {
+        $constructor = $this->getConstructorForContext('class');
+        $classBefore = new $constructor('tmp', [
+            'stmts' => [
+                new ClassMethod('tmpMethod', [
+                    'type'   => Visibility::getModifier('public'),
+                    'stmts' => [
+                        new MethodCall(new Variable('test'), 'someMethod'),
+                    ],
+                ]),
+            ],
+        ]);
+
+        $classAfter = new $constructor('tmp', [
+            'stmts' => [
+                new ClassMethod('tmpmethod', [
+                    'type'   => Visibility::getModifier('public'),
+                    'stmts' => [
+                        new MethodCall(new Variable('test'), 'someMethod'),
+                    ],
+                ]),
+            ],
+        ]);
+
+        $analyzer = new ClassMethodAnalyzer('class');
+        $report = $analyzer->analyze($classBefore, $classAfter);
+
+        Assert::assertNoDifference($report);
+    }
 }


### PR DESCRIPTION
Before this PR changing the case of a method would result in two warnings: method added (MINOR by default) and method removed (MAJOR by default). In reality PHP ignores the case of methods, and so this change should be PATCH at most.

This PR completely ignores situations where the case of a method has been changed (but if you would prefer this to be a "method case changed" type with level PATCH that's ok with me, let me know and I'll make the change).

Apologies for the formatting of tabs to spaces, if you'd like me to reset the formatting I can (although spaces are the [PSR-2 standard](https://www.php-fig.org/psr/psr-2/#1-overview))