### PR TITLE
Added compatibility with PHP 8.1

### DIFF
--- a/src/PHPSemVerChecker/Console/Application.php
+++ b/src/PHPSemVerChecker/Console/Application.php
@@ -25,7 +25,7 @@ class Application extends SymfonyApplication
 		parent::__construct('PHP Semantic Versioning Checker by Tom Rochette', self::VERSION);
 
 		// Suppress deprecated warnings
-		error_reporting(E_ALL ^E_DEPRECATED);
+		error_reporting(E_ALL & ~E_DEPRECATED);
 	}
 
 	/**

--- a/src/PHPSemVerChecker/Report/Report.php
+++ b/src/PHPSemVerChecker/Report/Report.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use IteratorAggregate;
 use PHPSemVerChecker\Operation\Operation;
 use PHPSemVerChecker\SemanticVersioning\Level;
+use Traversable;
 
 class Report implements ArrayAccess, IteratorAggregate
 {
@@ -158,6 +159,7 @@ class Report implements ArrayAccess, IteratorAggregate
 	 * @param string $offset
 	 * @return bool
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return isset($this->differences[$offset]);
@@ -165,8 +167,9 @@ class Report implements ArrayAccess, IteratorAggregate
 
 	/**
 	 * @param string $offset
-	 * @return array
+	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		return $this->differences[$offset];
@@ -176,6 +179,7 @@ class Report implements ArrayAccess, IteratorAggregate
 	 * @param string $offset
 	 * @param mixed  $value
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 		if ($offset === null) {
@@ -188,14 +192,16 @@ class Report implements ArrayAccess, IteratorAggregate
 	/**
 	 * @param string $offset
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
 		unset($this->differences[$offset]);
 	}
 
 	/**
-	 * @return \ArrayIterator|\Traversable
+	 * @return Traversable
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new ArrayIterator($this->differences);


### PR DESCRIPTION
Hello @tomzx

We still have problems with class \PHPSemVerChecker\Report\Report.
The problem looks like showed below when I run phpunit

`During inheritance of ArrayAccess: Uncaught PHPUnit\Framework\Exception: Deprecated: Return type of PHPSemVerChecker\Report\Report::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/andrewbess/work/projects/my-project/vendor/tomzx/php-semver-checker/src/PHPSemVerChecker/Report/Report.php:161`

We should add attribute #[\ReturnTypeWillChange] above methods offsetExists, offsetGet, offsetSet, offsetUnset, getIterator or we should add return types (that is not BIC) because the return types have been added there in PHP >= 8.0.

This pull request provides the fixes for the class `\PHPSemVerChecker\Report\Report` according to [php.net ArrayAccess interface](https://www.php.net/manual/en/class.arrayaccess.php) and [php.net IteratorAggregate interface](https://www.php.net/manual/en/class.iteratoraggregate.php). Also, we fixed error reporting in `src/PHPSemVerChecker/Console/Application.php`.
Finally, we checked these changes in PHP 7.4, 8.0, 8.1. It works well.

Cloud you please check it?

Thank you in advance.
